### PR TITLE
Add tests for TextToArcs

### DIFF
--- a/convokit/tests/text_processing/test_textToArcs.py
+++ b/convokit/tests/text_processing/test_textToArcs.py
@@ -1,0 +1,59 @@
+import unittest
+
+from convokit.tests.util import parsed_burr_sir_corpus
+from convokit.text_processing.textToArcs import TextToArcs
+
+class TestTextToArcs(unittest.TestCase):
+    def test_default_options(self):
+        transformer = TextToArcs(output_field='arcs')
+        corpus = parsed_burr_sir_corpus()
+
+        transformed_corpus = transformer.transform(corpus)
+        expected_arcs = [
+            [
+                'me_* pardon>* pardon_* pardon_me',
+                'aaron_* are>* are_* are_burr are_sir are_you burr_* burr_aaron sir_* you_*'
+            ],
+            [
+                'depends_* depends_that that>* that_*',
+                "'s_* asking_'s asking_* asking_who who>'s who>* who_*"
+            ]
+        ]
+        for expected_arc, utterance in zip(expected_arcs, transformed_corpus.iter_utterances()):
+            self.assertListEqual(expected_arc, utterance.meta['arcs'])
+
+    def test_dont_use_start(self):
+        transformer = TextToArcs(output_field='arcs', use_start=False)
+        corpus = parsed_burr_sir_corpus()
+
+        transformed_corpus = transformer.transform(corpus)
+        expected_arcs = [
+            [
+                'me_* pardon_* pardon_me',
+                'aaron_* are_* are_burr are_sir are_you burr_* burr_aaron sir_* you_*'
+            ],
+            [
+                'depends_* depends_that that_*',
+                "'s_* asking_'s asking_* asking_who who_*"
+            ]
+        ]
+        for expected_arc, utterance in zip(expected_arcs, transformed_corpus.iter_utterances()):
+            self.assertListEqual(expected_arc, utterance.meta['arcs'])
+
+    def test_root_only(self):
+        transformer = TextToArcs(output_field='arcs', root_only=True)
+        corpus = parsed_burr_sir_corpus()
+
+        transformed_corpus = transformer.transform(corpus)
+        expected_arcs = [
+            [
+                'pardon>* pardon_* pardon_me',
+                'are>* are_* are_burr are_sir are_you'
+            ],
+            [
+                'depends_* depends_that that>*',
+                "asking_'s asking_* asking_who who>'s who>*"
+            ]
+        ]
+        for expected_arc, utterance in zip(expected_arcs, transformed_corpus.iter_utterances()):
+            self.assertListEqual(expected_arc, utterance.meta['arcs'])

--- a/convokit/tests/util.py
+++ b/convokit/tests/util.py
@@ -60,6 +60,58 @@ def burr_sir_corpus():
     return Corpus(utterances=utterances)
 
 
+def parsed_burr_sir_corpus():
+    corpus = burr_sir_corpus()
+    utterance_infos = [
+        {'parsed': [
+            {
+                'rt': 0,
+                'toks': [
+                    {'tok': 'Pardon', 'tag': 'VB', 'dep': 'ROOT', 'dn': [1, 2]},
+                    {'tok': 'me', 'tag': 'PRP', 'dep': 'dobj', 'up': 0, 'dn': []},
+                    {'tok': '.', 'tag': '.', 'dep': 'punct', 'up': 0, 'dn': []}
+                ]
+            },
+            {
+                'rt': 0,
+                'toks': [
+                    {'tok': 'Are', 'tag': 'VBP', 'dep': 'ROOT', 'dn': [1, 3, 4, 5, 6]},
+                    {'tok': 'you', 'tag': 'PRP', 'dep': 'nsubj', 'up': 0, 'dn': []},
+                    {'tok': 'Aaron', 'tag': 'NNP', 'dep': 'compound', 'up': 3, 'dn': []},
+                    {'tok': 'Burr', 'tag': 'NNP', 'dep': 'attr', 'up': 0, 'dn': [2]},
+                    {'tok': ',', 'tag': ',', 'dep': 'punct', 'up': 0, 'dn': []},
+                    {'tok': 'sir', 'tag': 'NN', 'dep': 'npadvmod', 'up': 0, 'dn': []},
+                    {'tok': '?', 'tag': '.', 'dep': 'punct', 'up': 0, 'dn': []}
+                ]
+            }
+        ]},
+        {'parsed': [
+            {
+                'rt': 1,
+                'toks': [
+                    {'tok': 'That', 'tag': 'DT', 'dep': 'nsubj', 'up': 1, 'dn': []},
+                    {'tok': 'depends', 'tag': 'VBZ', 'dep': 'ROOT', 'dn': [0, 2]},
+                    {'tok': '.', 'tag': '.', 'dep': 'punct', 'up': 1, 'dn': []}
+                ]
+            },
+            {
+                'rt': 2,
+                'toks': [
+                    {'tok': 'Who', 'tag': 'WP', 'dep': 'nsubj', 'up': 2, 'dn': []},
+                    {'tok': "'s", 'tag': 'VBZ', 'dep': 'aux', 'up': 2, 'dn': []},
+                    {'tok': 'asking', 'tag': 'VBG', 'dep': 'ROOT', 'dn': [0, 1, 3]},
+                    {'tok': '?', 'tag': '.', 'dep': 'punct', 'up': 2, 'dn': []}
+                ]
+            }
+        ]}
+    ]
+    
+    for info_dict, utterance in zip(utterance_infos, corpus.iter_utterances()):
+        utterance.meta = info_dict
+    
+    return corpus
+
+
 def burr_sir_doc_1():
     return get_doc(
         vocab=en_vocab(),


### PR DESCRIPTION
A few things I want to bring up:

1. I'm realizing that writing unit tests that cover all code paths will take a huge amount of work. The `TextParser` took me a while, following that approach. I've opted to start writing tests that have less coverage but cover the main options that a given `Transformer` provides. So in the `TextToArcs` case, I'm writing tests for the default options, the `use_start` option, and the `root_only` option, but I haven't thoroughly tested the arc parsing logic. Does that sound reasonable for an initial pass of testing?
1. I don't have a strong enough grasp on dependency parsing to verify that the current outputs are correct; I've simply written tests that assume the current outputs are good. Can you point me to any resources on dependency parsing so I can know more for next time? Thanks in advance :D