### PR TITLE
fix a typo

### DIFF
--- a/examples/converting_movie_corpus.ipynb
+++ b/examples/converting_movie_corpus.ipynb
@@ -206,7 +206,7 @@
     "\n",
     "Additional information associated with the utterance may be saved as utterance level metadata. In this case, we consider the movie_id from which this utterance is extracted as an example for metadata. \n",
     "\n",
-    "An utterance possessing all the above information may be initiated by `Utterance(id=..., speaker =..., root =..., rely_to=..., timestamp=..., text =..., meta =...)`. We now create such `Utterance` objects for the utterances in our dataset. Note that normally we would provide `root` and `reply_to` information at the time of instantiation, but we will defer it to later as such information need to be retrieved from a different file. "
+    "An utterance possessing all the above information may be initiated by `Utterance(id=..., speaker =..., root =..., reply_to=..., timestamp=..., text =..., meta =...)`. We now create such `Utterance` objects for the utterances in our dataset. Note that normally we would provide `root` and `reply_to` information at the time of instantiation, but we will defer it to later as such information need to be retrieved from a different file. "
    ]
   },
   {


### PR DESCRIPTION
I spot a small typo in one of the examples. I believe it is necessary to correct it because it is the name of one of Utterance's attributes. There should be no changes in the output.