### PR TITLE
Typecheck for utterance text

### DIFF
--- a/convokit/model/utterance.py
+++ b/convokit/model/utterance.py
@@ -38,13 +38,15 @@ class Utterance(CorpusComponent):
         self.user = speaker # for backwards compatbility
         self.conversation_id = conversation_id if conversation_id is not None else root
         if self.conversation_id is not None and not isinstance(self.conversation_id, str):
-            warn("Utterance conversation_id must be a string: conversation_id has been casted to a string.")
+            warn("Utterance conversation_id must be a string: conversation_id of utterance with ID: {} "
+                 "has been casted to a string.".format(self.id))
             self.conversation_id = str(self.conversation_id)
         self._root = self.conversation_id
         self.reply_to = reply_to
         self.timestamp = timestamp # int(timestamp) if timestamp is not None else timestamp
         if not isinstance(text, str):
-            warn("Utterance text must be a string: text has been casted to a string.".format(self.obj_type))
+            warn("Utterance text must be a string: text of utterance with ID: {} "
+                 "has been casted to a string.".format(self.id))
             text = '' if text is None else str(text)
         self.text = text
 

--- a/convokit/model/utterance.py
+++ b/convokit/model/utterance.py
@@ -28,7 +28,7 @@ class Utterance(CorpusComponent):
     def __init__(self, owner=None, id: Optional[str] = None, speaker: Optional[Speaker] = None,
                  user: Optional[Speaker] = None, conversation_id: Optional[str] = None,
                  root: Optional[str] = None, reply_to: Optional[str] = None,
-                 timestamp: Optional[int] = None, text: Optional[str] = None,
+                 timestamp: Optional[int] = None, text: str = '',
                  meta: Optional[Dict] = None):
         super().__init__(obj_type="utterance", owner=owner, id=id, meta=meta)
         speaker_ = speaker if speaker is not None else user
@@ -38,11 +38,14 @@ class Utterance(CorpusComponent):
         self.user = speaker # for backwards compatbility
         self.conversation_id = conversation_id if conversation_id is not None else root
         if self.conversation_id is not None and not isinstance(self.conversation_id, str):
-            warn("conversation_id must be a string. conversation_id has been casted to a string.".format(self.obj_type))
+            warn("Utterance conversation_id must be a string: conversation_id has been casted to a string.")
             self.conversation_id = str(self.conversation_id)
         self._root = self.conversation_id
         self.reply_to = reply_to
         self.timestamp = timestamp # int(timestamp) if timestamp is not None else timestamp
+        if not isinstance(text, str):
+            warn("Utterance text must be a string: text has been casted to a string.".format(self.obj_type))
+            text = '' if text is None else str(text)
         self.text = text
 
     def _get_root(self):


### PR DESCRIPTION
Enforces that the utterance text is a string. If None, then the text is the empty string. If some non-string object, then it gets typecast into a string.