### PR TITLE
Added 'from_pandas' method to create Corpus from DataFrames.

### DIFF
--- a/convokit/model/corpus.py
+++ b/convokit/model/corpus.py
@@ -1313,6 +1313,7 @@ class Corpus:
                 metadata = None
             
             # extracting speaker metadata from speakers_df
+            speakers_df.columns = [col.replace('meta.', '') for col in speakers_df.columns]
             speaker_meta = speakers_df[speakers_df['id'] == row['speaker']][speaker_meta_cols].to_dict(orient='records')[0] if speaker_meta_cols else None
             
             # adding utterance in utterance list

--- a/convokit/model/corpus.py
+++ b/convokit/model/corpus.py
@@ -1300,6 +1300,7 @@ class Corpus:
 
         utterance_meta_cols = extract_meta_from_df(utterances_df)
         speaker_meta_cols = extract_meta_from_df(speakers_df)
+        speakers_df.columns = [col.replace('meta.', '') for col in speakers_df.columns]
 
         utterance_list = []
         for index, row in tqdm(utterances_df.iterrows()):
@@ -1313,7 +1314,6 @@ class Corpus:
                 metadata = None
             
             # extracting speaker metadata from speakers_df
-            speakers_df.columns = [col.replace('meta.', '') for col in speakers_df.columns]
             speaker_meta = speakers_df[speakers_df['id'] == row['speaker']][speaker_meta_cols].to_dict(orient='records')[0] if speaker_meta_cols else None
             
             # adding utterance in utterance list

--- a/convokit/model/corpus.py
+++ b/convokit/model/corpus.py
@@ -1309,7 +1309,7 @@ class Corpus:
             if utterance_meta_cols:
                 metadata = {}
                 for meta_col in utterance_meta_cols:
-                    metadata[meta_col] = row[meta_col]
+                    metadata[meta_col] = row['meta.' + meta_col]
             else: 
                 metadata = None
             
@@ -1317,7 +1317,7 @@ class Corpus:
             speaker_meta = speakers_df[speakers_df['id'] == row['speaker']][speaker_meta_cols].to_dict(orient='records')[0] if speaker_meta_cols else None
             
             # adding utterance in utterance list
-            utterance_list.append(Utterance(id=str(row['id']), speaker=Speaker(row['speaker'], speaker_meta),
+            utterance_list.append(Utterance(id=str(row['id']), speaker=Speaker(id=row['speaker'], meta=speaker_meta),
                                             conversation_id=row['conversation_id'], reply_to=row['reply_to'],
                                             timestamp=row['timestamp'], text=row['text'],
                                             meta=metadata))

--- a/convokit/model/corpusHelper.py
+++ b/convokit/model/corpusHelper.py
@@ -366,6 +366,7 @@ def extract_meta_from_df(df):
 
 def add_conv_meta_df(conversations_df, corpus):
     conv_meta_cols = extract_meta_from_df(conversations_df)
+    conversations_df.columns = [col.replace('meta.', '') for col in conversations_df.columns]
     for convo in corpus.iter_conversations():
         # get the conv_id for the conversation by checking from utterance info
         convo_id = convo.get_id()

--- a/convokit/model/corpusHelper.py
+++ b/convokit/model/corpusHelper.py
@@ -359,3 +359,18 @@ def dump_jsonlist_from_dict(entries, filename, index_key='id', value_key='value'
         for k, v in entries.items():
             json.dump({index_key: k, value_key: v}, f)
             f.write('\n')
+
+def extract_meta_from_df(df):
+    meta_cols = [col for col in df if col.startswith('meta')]
+    return meta_cols
+
+def add_conv_meta_df(conversations_df, corpus):
+    conv_meta_cols = extract_meta_from_df(conversations_df)
+    for convo in corpus.iter_conversations():
+        # get the conv_id for the conversation by checking from utterance info
+        convo_id = convo.get_id()
+        conversation_meta = conversations_df[conversations_df['id'] == convo_id][conv_meta_cols].to_dict(orient='records')[0] if conv_meta_cols else None
+
+        convo.meta.update(conversation_meta)
+    
+    return corpus

--- a/convokit/model/corpusHelper.py
+++ b/convokit/model/corpusHelper.py
@@ -361,7 +361,7 @@ def dump_jsonlist_from_dict(entries, filename, index_key='id', value_key='value'
             f.write('\n')
 
 def extract_meta_from_df(df):
-    meta_cols = [col for col in df if col.startswith('meta')]
+    meta_cols = [col.split(".")[1] for col in df if col.startswith('meta')]
     return meta_cols
 
 def add_conv_meta_df(conversations_df, corpus):
@@ -370,7 +370,6 @@ def add_conv_meta_df(conversations_df, corpus):
         # get the conv_id for the conversation by checking from utterance info
         convo_id = convo.get_id()
         conversation_meta = conversations_df[conversations_df['id'] == convo_id][conv_meta_cols].to_dict(orient='records')[0] if conv_meta_cols else None
-
         convo.meta.update(conversation_meta)
     
     return corpus

--- a/convokit/tests/general/test_from_pandas.py
+++ b/convokit/tests/general/test_from_pandas.py
@@ -5,20 +5,28 @@ from convokit import download
 class CorpusFromPandas(unittest.TestCase):
 
     def setUp(self) -> None:
-        self.corpus = Corpus(download('subreddit-Cornell'))
-
-    def test_reconstruction(self):
-        """
-        Test that reconstructing the Corpus from outputted dataframes results in the same number of corpus components
-        """
-
+        self.corpus = Corpus(download('subreddit-hey'))
         utt_df = self.corpus.get_utterances_dataframe()
         convo_df = self.corpus.get_conversations_dataframe()
         speaker_df = self.corpus.get_speakers_dataframe()
-        new_corpus = Corpus.from_pandas(speaker_df, utt_df, convo_df)
-        assert len(new_corpus.speakers) == len(self.corpus.speakers)
-        assert len(new_corpus.conversations) == len(self.corpus.conversations)
-        assert len(new_corpus.utterances) == len(self.corpus.utterances)
+        self.new_corpus = Corpus.from_pandas(speaker_df, utt_df, convo_df)
+
+    def test_reconstruction_stats(self):
+        """
+        Test that reconstructing the Corpus from outputted dataframes results in the same number of corpus components
+        """
+        assert len(self.new_corpus.speakers) == len(self.corpus.speakers)
+        assert len(self.new_corpus.conversations) == len(self.corpus.conversations)
+        assert len(self.new_corpus.utterances) == len(self.corpus.utterances)
+
+    def test_reconstruction_metadata(self):
+        assert set(self.corpus.random_utterance().meta) == set(self.new_corpus.random_utterance().meta)
+        assert set(self.corpus.random_conversation().meta) == set(self.new_corpus.random_conversation().meta)
+        assert set(self.corpus.random_speaker().meta) == set(self.new_corpus.random_speaker().meta)
+
+    def test_convo_reconstruction(self):
+        for convo in self.new_corpus.iter_conversations():
+            assert convo.check_integrity(verbose=False)
 
 if __name__ == '__main__':
     unittest.main()

--- a/convokit/tests/general/test_from_pandas.py
+++ b/convokit/tests/general/test_from_pandas.py
@@ -9,16 +9,16 @@ class CorpusFromPandas(unittest.TestCase):
 
     def test_reconstruction(self):
         """
-        Test basic meta functions
+        Test that reconstructing the Corpus from outputted dataframes results in the same number of corpus components
         """
 
         utt_df = self.corpus.get_utterances_dataframe()
         convo_df = self.corpus.get_conversations_dataframe()
         speaker_df = self.corpus.get_speakers_dataframe()
-        print(utt_df.columns)
         new_corpus = Corpus.from_pandas(speaker_df, utt_df, convo_df)
-        self.corpus.print_summary_stats()
-        new_corpus.print_summary_stats()
+        assert len(new_corpus.speakers) == len(self.corpus.speakers)
+        assert len(new_corpus.conversations) == len(self.corpus.conversations)
+        assert len(new_corpus.utterances) == len(self.corpus.utterances)
 
 if __name__ == '__main__':
     unittest.main()

--- a/convokit/tests/general/test_from_pandas.py
+++ b/convokit/tests/general/test_from_pandas.py
@@ -1,0 +1,24 @@
+import unittest
+from convokit.model import Utterance, Speaker, Corpus
+from convokit import download
+
+class CorpusFromPandas(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.corpus = Corpus(download('subreddit-Cornell'))
+
+    def test_reconstruction(self):
+        """
+        Test basic meta functions
+        """
+
+        utt_df = self.corpus.get_utterances_dataframe()
+        convo_df = self.corpus.get_conversations_dataframe()
+        speaker_df = self.corpus.get_speakers_dataframe()
+        print(utt_df.columns)
+        new_corpus = Corpus.from_pandas(speaker_df, utt_df, convo_df)
+        self.corpus.print_summary_stats()
+        new_corpus.print_summary_stats()
+
+if __name__ == '__main__':
+    unittest.main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ dill>=0.2.9
 torch>=1.2.0
 clean-text>=0.1.1
 joblib>=0.13.2
+tqdm


### PR DESCRIPTION
In response to #69. 
Added a static method in the corpus class to create a corpus object from speakers, utterances and conversations dataframes. Also added helper functions to extract required metadata from the dataframes.

Utterances DataFrame is expected to contain all primary fields as columns. Speakers and Conversations are expected to have an "id" column; metadata columns are optional for all dataframes. Metadata columns are expected to have a "meta" prefix, as specified in #69.