### PR TITLE
Pairer doc update

### DIFF
--- a/convokit/paired_prediction/pairer.py
+++ b/convokit/paired_prediction/pairer.py
@@ -9,29 +9,16 @@ from convokit import Transformer, CorpusComponent, Corpus
 
 class Pairer(Transformer):
     """
-    The Pairer Transformer annotates the Corpus with the pairing information that is needed to run some paired prediction analysis (e.g. see the PairedPrediction and Paired BoW modules.)
-
-    Pairer sets this pairing up. For this example:
-
-    - The obj_type is 'utterance' (since we compare utterances)
-    - The pairing_func is supposed to extract the identifier that would identify the object as part of the pair. In this case, that would be the Utterance's conversation id since we want utterances from the same conversation.
-    - We need to distinguish between utterances where Rachel speaks to Monica vs. Chandler.
-        the pos_label_func and neg_label_func is how we can specify this (e.g. lambda utt: utt.meta['target']), where positive instances might be arbitrarily refer to targetting Monica, and negative for targetting Chandler.
-    - pair_mode denotes how many pairs to use per context.
-        For example, a Conversation will likely have Rachel address Monica and Chandler each multiple times.
-        This means that there are multiple positive and negative instances that can be used to form pairs.
-        We could randomly pick one pair of instances ('random'), or the first pair of instances ('first'),
-        or the maximum pairs of instances ('maximize').
-
-    Pairer saves this pairing information into the object metadata.
-
-    - pair_id is the 'id' that uniquely identifies a pair of positive and negative instances,
-        and is the output from the pairing_func.
-    - label (or pair_obj_label) denotes whether the object is the positive or negative instance of the pair
-    - pair_orientation denotes whether to use the pair itself as a positive or negative data point in a predictive
-        classifier. 'pos' means the difference between the objects in the pair should be computed as
-        [+ve obj features] - [-ve obj features], and 'neg' means it should be computed as
-        [-ve obj features] - [+ve obj features].
+    Pairer transformer sets up pairing to be used for paired prediction analyses.
+    :param obj_type: type of Corpus object to classify: ‘conversation’, ‘speaker’, or ‘utterance’
+    :param pairing_func: the Corpus object characteristic to pair on, e.g. to pair on the first 10 characters of a
+        well-structured id, use lambda obj: obj.id[:10]
+    :param pos_label_func: the function to check if the object is a positive instance
+    :param neg_label_func: the function to check if the object is a negative instance
+    :param pair_mode: 'random': pick a single positive and negative object pair randomly (default), 'maximize': pick the maximum number of positive and negative object pairs possible randomly, or 'first': pick the first positive and negative object pair found.
+    :param pair_id_attribute_name: metadata attribute name to use in annotating object with pair id, default: "pair_id". The value is determined by the output of pairing_func. If pair_mode is 'maximize', the value is the output of pairing_func + "_[i]", where i is the ith pair extracted from a given context.
+    :param label_attribute_name: metadata attribute name to use in annotating object with whether it is positive or negative, default: "pair_obj_label"
+    :param pair_orientation_attribute_name: metadata attribute name to use in annotating object with pair orientation, default: "pair_orientation"
     """
 
     def __init__(self, obj_type: str,

--- a/convokit/paired_prediction/pairer.py
+++ b/convokit/paired_prediction/pairer.py
@@ -33,18 +33,6 @@ class Pairer(Transformer):
                  pair_orientation_attribute_name: str = "pair_orientation",
                  pair_orientation_feat_name=None
                  ):
-
-        """
-        :param pairing_func: the Corpus object characteristic to pair on, e.g. to pair on the first 10 characters of a
-            well-structured id, use lambda obj: obj.id[:10]
-        :param pos_label_func: The function to check if the object is a positive instance
-        :param neg_label_func: The function to check if the object is a negative instance
-        :param pair_mode: 'random': pick a single positive and negative object pair randomly (default), 'maximize': pick the maximum number of positive and negative object pairs possible randomly, or 'first': pick the first positive and negative object pair found.
-        :param pair_id_attribute_name: metadata attribute name to use in annotating object with pair id, default: "pair_id". The value is determined by the output of pairing_func. If pair_mode is 'maximize', the value is the output of pairing_func + "_[i]", where i is the ith pair extracted from a given context.
-        :param label_attribute_name: metadata attribute name to use in annotating object with whether it is positive or negative, default: "pair_obj_label"
-        :param pair_orientation_attribute_name: metadata attribute name to use in annotating object with pair orientation, default: "pair_orientation"
-
-        """
         assert obj_type in ["speaker", "utterance", "conversation"]
         self.obj_type = obj_type
         self.pairing_func = pairing_func

--- a/doc/source/pairedprediction.rst
+++ b/doc/source/pairedprediction.rst
@@ -16,12 +16,11 @@ do this to look only at Conversations where Rachel, Monica, and Chandler are all
 utterances where Rachel speaks to Monica and Rachel speaks to Chandler *within* that Conversation and look
 for differences between these paired sets of utterances.
 
+Documentation for the two transformers that do paired prediction task is presented below. PairedPrediction transformer uses corpus object’s metadata features for predictions, while PairedVectorPrediction transformer utilizes vector data associated with the object. Also, see the documentation for :doc:`Pairer transformer <pairer>`, which sets up the pairs needed in paired prediction analysis. 
+
 Example usage: `Using Hyperconvo features to predict conversation growth on Reddit in a paired setting <https://github.com/CornellNLP/Cornell-Conversational-Analysis-Toolkit/blob/master/examples/hyperconvo/predictive_tasks.ipynb>`_
 
 .. automodule:: convokit.paired_prediction.pairedPrediction
-    :members:
-
-.. automodule:: convokit.paired_prediction.pairer
     :members:
 
 .. automodule:: convokit.paired_prediction.pairedVectorPrediction

--- a/doc/source/pairer.rst
+++ b/doc/source/pairer.rst
@@ -1,0 +1,19 @@
+The Pairer transformer annotates the Corpus with the pairing information that is needed to run some of the paired prediction analyses (e.g. see the documentation for :doc:`PairedPrediction and PairedVectorPrediction transformers <pairedprediction>`).
+
+To explain how the Pairer works in more detail, consider the example of the Friends TV series, referenced with :doc:`paired prediction transformers <pairedprediction>`. We are interested in examining how differently Rachel talks to Monica and Chandler. When considering all utterances by Rachel to Monica and Chandler in the comparative analysis, the differences we observe may inadvertently be due to different topics of conversations. Thus, in order to control for the variable context of conversations, one might want to focus on utterances from conversations in which the three — Rachel, Monica, and Chandler — are all present. More precisely, we would like to pair Rachel’s utterances directed to Monica with utterances directed to Chandler if they are part of the same conversation. 
+
+Next, we are going to show how we can set up this pairing from the example using Pairer transformer:
+
+    - The ``obj_type`` is `“utterance”`, since we compare Rachel’s utterances
+    - The ``pairing_func`` is supposed to extract the identifier that would identify the object as part of the pair. In this case, that would be the Utterance's conversation id since we want utterances from the same conversation.
+    - We need to distinguish between utterances where Rachel speaks to Monica vs. Chandler. The ``pos_label_func`` and ``neg_label_func`` is how we can specify this (e.g. ``lambda utt: utt.meta['target’]``), where positive instances might be arbitrarily refer to targetting Monica, and negative for targetting Chandler.
+    - ``pair_mode`` denotes how many pairs to use per context. For example, a Conversation will likely have Rachel address Monica and Chandler each multiple times. This means that there are multiple positive and negative instances that can be used to form pairs. We could randomly pick one pair of instances ("random"), or the first pair of instances ("first"), or the maximum pairs of instances ("maximize").
+Pairer saves this pairing information into the object metadata.
+
+    - ``pair_id`` is the "id" that uniquely identifies a pair of positive and negative instances, and is the output from the pairing_func.
+    - ``pair_obj_label`` denotes whether the object is the positive or negative instance of the pair
+    - ``pair_orientation`` denotes whether to use the pair itself as a positive or negative data point in a predictive classifier. "pos" means the difference between the objects in the pair should be computed as [+ve obj features] - [-ve obj features], and "neg" means it should be computed as [-ve obj features] - [+ve obj features].
+
+
+.. automodule:: convokit.paired_prediction.pairer
+    :members:


### PR DESCRIPTION
Separates PairedPrediction documentation into two parts: doc file for Pairer transformer and doc file for PairedPrediction and PairedVectorPrediction transformers. Each of the two files links to the other. In the Transformers/Analysis tree in the documentation site, we still have Paired Prediction doc (with the two paired prediction transformers). 