### PR TITLE
Workflow: rsync Set Group

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -21,7 +21,7 @@ jobs:
     - name: rsync docs
       uses: burnett01/rsync-deployments@master
       with:
-        switches: -vzr
+        switches: -vzr --chown=":sauna"
         path: docs/build/
         remote_path: ${{ secrets.DEPLOY_DOCS_PATH }}
         remote_host: ${{ secrets.DEPLOY_HOST }}

--- a/.github/workflows/rsync-download-config.yml
+++ b/.github/workflows/rsync-download-config.yml
@@ -13,7 +13,7 @@ jobs:
     - name: rsync download config
       uses: burnett01/rsync-deployments@master
       with:
-        switches: -vzr
+        switches: -vzr --chown=":sauna"
         path: download_config.json
         remote_path: ${{ secrets.BASE_DIRECTORY_PATH }}
         remote_host: ${{ secrets.DEPLOY_HOST }}

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -20,7 +20,7 @@ jobs:
     - name: rsync homepage files
       uses: burnett01/rsync-deployments@master
       with:
-        switches: -vzr
+        switches: -vzr --chown=":sauna"
         path: website/docs/build/
         remote_path: ${{ secrets.DEPLOY_WEBSITE_PATH }}
         remote_host: ${{ secrets.DEPLOY_HOST }}


### PR DESCRIPTION
### Description
<!--- Describe your changes in detail -->
<!--- What kind of change does this PR introduce?** (Bug fix, feature, dataset, docs update, ...) -->

Update workflow so that rsync automatically set group to sauna when sending the built documentation and website to Belafonte.